### PR TITLE
Improve metering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # js-wasm-metering
 
-Simple wasm metering.
+Wasm metering done similarly to Wasmer. The original made use of host calls to meter gas but we've changed the implementation to keep track of the gas limit from within the WASM world.
 
-This is a fork of https://www.npmjs.com/package/@aldea/wasm-metering?activeTab=readme with some modifications to make more truncate opcodes work. This in turn is just a wrapper around https://github.com/warp-contracts/warp-wasm-metering, but we moved most of the code inside this repository.
+This started as a fork of https://www.npmjs.com/package/@aldea/wasm-metering?activeTab=readme with some modifications to make more truncate opcodes work. This in turn is just a wrapper around https://github.com/warp-contracts/warp-wasm-metering, but we moved most of the code inside this repository.
 
 There is also code adapted from https://github.com/warp-contracts/warp-wasm-json-toolkit.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"type": "module",
 	"module": "src/index.js",
 	"main": "src/index.js",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"scripts": {
 		"fmt": "bunx biome check --write ."
 	},

--- a/src/json2wasm.js
+++ b/src/json2wasm.js
@@ -34,7 +34,7 @@ const EXTERNAL_KIND = (json2wasm.EXTERNAL_KIND = {
 	global: 3,
 });
 
-const SECTION_IDS = (json2wasm.SECTION_IDS = {
+export const SECTION_IDS = (json2wasm.SECTION_IDS = {
 	custom: 0,
 	type: 1,
 	import: 2,

--- a/src/meter-json.js
+++ b/src/meter-json.js
@@ -1,214 +1,213 @@
 const text2json = require("./text2json.js");
-const SECTION_IDS = require("./json2wasm").SECTION_IDS;
+const SECTION_IDS = require("./json2wasm.js").SECTION_IDS;
 
 // gets the cost of an operation for entry in a section from the cost table
 function getCost(json, costTable = {}, defaultCost = 0) {
-	let cost = 0;
-	// finds the default cost
-	const fallbackCost =
-		costTable.DEFAULT !== undefined ? costTable.DEFAULT : defaultCost;
+  let cost = 0;
+  // finds the default cost
+  const fallbackCost =
+    costTable.DEFAULT !== undefined ? costTable.DEFAULT : defaultCost;
 
-	if (Array.isArray(json)) {
-		for (const el of json) {
-			cost += getCost(el, costTable);
-		}
-	} else if (typeof json === "object") {
-		for (const propName in json) {
-			const propCost = costTable[propName];
-			if (propCost) {
-				cost += getCost(json[propName], propCost, fallbackCost);
-			}
-		}
-	} else if (costTable[json] === undefined) {
-		cost = fallbackCost;
-	} else {
-		cost = costTable[json];
-	}
-	return cost;
+  if (Array.isArray(json)) {
+    for (const el of json) {
+      cost += getCost(el, costTable);
+    }
+  } else if (typeof json === "object") {
+    for (const propName in json) {
+      const propCost = costTable[propName];
+      if (propCost) {
+        cost += getCost(json[propName], propCost, fallbackCost);
+      }
+    }
+  } else if (costTable[json] === undefined) {
+    cost = fallbackCost;
+  } else {
+    cost = costTable[json];
+  }
+  return cost;
 }
 
-// meters a single code entrie
-function meterCodeEntry(entry, costTable, meterFuncIndex, meterType, cost) {
-	function meteringStatement(cost, meteringImportIndex) {
-		return text2json(`${meterType}.const ${cost} call ${meteringImportIndex}`);
-	}
+// meters a single code entry
+function meterCodeEntry(entry, costTable, cost, meterIndex, exhaustedIndex) {
+  // Generate the metering opcodes similar to how Wasmer does it.
+  function meteringStatement(accumulatedCost) {
+    return text2json(`get_global ${meterIndex}`)
+      .concat(text2json(`i64.const ${accumulatedCost}`))
+      .concat(text2json("i64.lt_u"))
+      .concat([{ name: "if", immediates: "block_type" }])
+      .concat(text2json("i32.const 1"))
+      .concat(text2json(`set_global ${exhaustedIndex}`))
+      .concat(text2json("unreachable"))
+      .concat(text2json("end"))
+      .concat(text2json(`get_global ${meterIndex}`))
+      .concat(text2json(`i64.const ${accumulatedCost}`))
+      .concat(text2json("i64.sub"))
+      .concat(text2json(`set_global ${meterIndex}`));
+  }
 
-	function remapOp(op, funcIndex) {
-		if (op.name === "call" && op.immediates >= funcIndex) {
-			op.immediates = (++op.immediates).toString();
-		}
-	}
+  // operations that can possible cause a branch
+  const branchingOps = new Set([
+    "loop",
+    "end",
+    "if",
+    "else",
+    "br",
+    "br_table",
+    "br_if",
+    "call",
+    "call_indirect",
+    "return",
+  ]);
 
-	// operations that can possible cause a branch
-	const branchingOps = new Set([
-		"loop",
-		"end",
-		"if",
-		"else",
-		"br",
-		"br_table",
-		"br_if",
-		"call",
-		"call_indirect",
-		"return",
-	]);
-	let code = entry.code.slice();
-	let meteredCode = [];
+  let code = entry.code.slice();
+  let meteredCode = [];
 
-	cost += getCost(entry.locals, costTable.local);
+  cost += getCost(entry.locals, costTable.local);
 
-	while (code.length) {
-		let i = 0;
+  while (code.length) {
+    let i = 0;
 
-		// meters a segment of wasm code
-		while (true) {
-			const op = code[i++];
-			remapOp(op, meterFuncIndex);
+    // meters a segment of wasm code
+    while (true) {
+      const op = code[i++];
 
-			cost += getCost(op.name, costTable.code);
-			if (branchingOps.has(op.name)) {
-				break;
-			}
-		}
+      cost += getCost(op.name, costTable.code);
+      if (branchingOps.has(op.name)) {
+        break;
+      }
+    }
 
-		// get the segment of code to be metered
-		let segment = code.slice(0, i);
+    // get the segment of code to be metered
+    let segment = code.slice(0, i);
 
-		// add the metering statement when there's a cost to meter
-		if (cost !== 0) {
-			const mStatement = meteringStatement(cost, meterFuncIndex);
-			// Mimic wasmer's behavior by inserting the metering statement before the last operation
-			const lastOp = segment.pop();
-			segment = segment.concat(mStatement);
-			segment.push(lastOp);
-		}
+    // add the metering statement when there's a cost to meter
+    if (cost !== 0) {
+      const mStatement = meteringStatement(cost);
+      // Mimic wasmer's behavior by inserting the metering statement before the last operation
+      const lastOp = segment.pop();
+      segment = segment.concat(mStatement);
+      segment.push(lastOp);
+    }
 
-		meteredCode = meteredCode.concat(segment);
+    meteredCode = meteredCode.concat(segment);
 
-		// start a new segment
-		code = code.slice(i);
-		cost = 0;
-	}
+    // start a new segment
+    code = code.slice(i);
+    cost = 0;
+  }
 
-	entry.code = meteredCode;
-	return entry;
+  entry.code = meteredCode;
+  return entry;
 }
 
 /**
  * Injects metering into a JSON output of [wasm2json](https://github.com/ewasm/wasm-json-toolkit#wasm2json)
  * @param {Object} json the json tobe metered
  * @param {Object} costTable the cost table to meter with.
- * @param {Object} opts
- * @param {String} [opts.moduleStr='metering'] the import string for the metering function
- * @param {String} [opts.fieldStr='usegas'] the field string for the metering function
- * @param {String} [opts.meterType='i64'] the register type that is used to meter. Can be `i64`, `i32`, `f64`, `f32`
  * @return {Object} the metered json
  */
-exports.meterJSON = (json, costTable, opts) => {
-	function findSection(module, sectionName) {
-		return module.find((section) => section.name === sectionName);
-	}
+exports.meterJSON = (json, costTable) => {
+  function findSection(module, sectionName) {
+    return module.find((section) => section.name === sectionName);
+  }
 
-	function createSection(module, name) {
-		const newSectionId = SECTION_IDS[name];
-		for (const index in module) {
-			const section = module[index];
-			const sectionId = SECTION_IDS[section.name];
-			if (sectionId) {
-				if (newSectionId < sectionId) {
-					// inject a new section
-					module.splice(index, 0, {
-						name,
-						entries: [],
-					});
-					return;
-				}
-			}
-		}
-	}
+  function createSection(module, name) {
+    const newSectionId = SECTION_IDS[name];
+    for (const index in module) {
+      const section = module[index];
+      const sectionId = SECTION_IDS[section.name];
+      if (sectionId) {
+        if (newSectionId < sectionId) {
+          // inject a new section
+          module.splice(index, 0, {
+            name,
+            entries: [],
+          });
+          return;
+        }
+      }
+    }
+  }
 
-	let funcIndex = 0;
-	let functionModule, typeModule;
+  // add nessicarry sections iff they don't exist
+  if (!findSection(json, "export")) createSection(json, "export");
+  if (!findSection(json, "global")) createSection(json, "global");
 
-	let { moduleStr, fieldStr, meterType } = opts;
+  const globalMeteringPoints = {
+    type: {
+      contentType: "i64",
+      mutability: 1,
+    },
+    init: {
+      return_type: "i64",
+      name: "const",
+      // We set the initial gas limit to 0 and expect the caller to set the gas limit
+      // through the export.
+      immediates: "0",
+    },
+  };
+  const globalOutOfGas = {
+    type: {
+      contentType: "i32",
+      mutability: 1,
+    },
+    init: {
+      return_type: "i32",
+      name: "const",
+      immediates: "0",
+    },
+  };
 
-	// set defaults
-	if (!moduleStr) moduleStr = "metering";
-	if (!fieldStr) fieldStr = "usegas";
-	if (!meterType) meterType = "i32";
+  const exportMeteringPoints = {
+    field_str: "metering_remaining_points",
+    kind: "global",
+    index: Number.NaN,
+  };
+  const exportOutOfGas = {
+    field_str: "metering_points_exhausted",
+    kind: "global",
+    index: Number.NaN,
+  };
 
-	// add nessicarry sections iff they don't exist
-	if (!findSection(json, "type")) createSection(json, "type");
-	if (!findSection(json, "import")) createSection(json, "import");
+  json = json.slice(0);
 
-	const importJson = {
-		moduleStr: moduleStr,
-		fieldStr: fieldStr,
-		kind: "function",
-	};
-	const importType = {
-		form: "func",
-		params: [meterType],
-	};
+  for (let section of json) {
+    section = Object.assign(section);
+    switch (section.name) {
+      case "type":
+        break;
+      case "function":
+        break;
+      case "import":
+        break;
+      case "export":
+        section.entries.push(exportMeteringPoints);
+        section.entries.push(exportOutOfGas);
+        break;
+      case "element":
+        break;
+      case "start":
+        break;
+      case "global":
+        exportMeteringPoints.index =
+          section.entries.push(globalMeteringPoints) - 1;
+        exportOutOfGas.index = section.entries.push(globalOutOfGas) - 1;
+        break;
+      case "code":
+        for (const i in section.entries) {
+          const entry = section.entries[i];
 
-	json = json.slice(0);
+          meterCodeEntry(
+            entry,
+            costTable.code,
+            0,
+            exportMeteringPoints.index,
+            exportOutOfGas.index
+          );
+        }
+        break;
+    }
+  }
 
-	for (let section of json) {
-		section = Object.assign(section);
-		switch (section.name) {
-			case "type":
-				// mark the import index
-				importJson.type = section.entries.push(importType) - 1;
-				// save for use for the code section
-				typeModule = section;
-				break;
-			case "function":
-				// save for use for the code section
-				functionModule = section;
-				break;
-			case "import":
-				for (const entry of section.entries) {
-					if (entry.moduleStr === moduleStr && entry.fieldStr === fieldStr) {
-						throw new Error("importing metering function is not allowed");
-					}
-					if (entry.kind === "function") {
-						funcIndex++;
-					}
-				}
-				// append the metering import
-				section.entries.push(importJson);
-				break;
-			case "export":
-				for (const entry of section.entries) {
-					if (entry.kind === "function" && entry.index >= funcIndex) {
-						entry.index++;
-					}
-				}
-				break;
-			case "element":
-				for (const entry of section.entries) {
-					// remap elements indices
-					entry.elements = entry.elements.map((el) =>
-						el >= funcIndex ? ++el : el,
-					);
-				}
-				break;
-			case "start":
-				// remap start index
-				if (section.index >= funcIndex) section.index++;
-				break;
-			case "code":
-				for (const i in section.entries) {
-					const entry = section.entries[i];
-					const typeIndex = functionModule.entries[i];
-					const type = typeModule.entries[typeIndex];
-					const cost = getCost(type, costTable.type);
-
-					meterCodeEntry(entry, costTable.code, funcIndex, meterType, cost);
-				}
-				break;
-		}
-	}
-
-	return json;
+  return json;
 };


### PR DESCRIPTION
## Motivation

Make metering more performant by avoiding host calls.

## Explanation of Changes

Instead we keep track of the gas limit within the WASM world, similar to how Wasmer does gas metering.

## Testing

Tests in the sdk repo still pass.

## Related PRs and Issues

Related to https://github.com/sedaprotocol/seda-sdk/issues/158