### PR TITLE
Improve performance with Preallocated buffer and hardcoded metering opcodes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,13 +4,12 @@
     "": {
       "name": "wasm-metering-ts",
       "dependencies": {
-        "buffer-pipe": "^0.0.5",
         "leb128": "^0.0.5",
-        "warp-isomorphic": "^1.0.7",
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "latest",
+        "@types/leb128": "^0.0.0",
       },
       "peerDependencies": {
         "typescript": "^5.7.3",
@@ -36,25 +35,21 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
 
-    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+    "@types/bn.js": ["@types/bn.js@4.11.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg=="],
 
     "@types/bun": ["@types/bun@1.2.3", "", { "dependencies": { "bun-types": "1.2.3" } }, "sha512-054h79ipETRfjtsCW9qJK8Ipof67Pw9bodFWmkfkaUaRiIQ1dIV2VTlheshlBx3mpKr0KeK8VqnMMCtgN9rQtw=="],
+
+    "@types/leb128": ["@types/leb128@0.0.0", "", { "dependencies": { "@types/bn.js": "^4.0.0", "@types/node": "*" } }, "sha512-QvSlqftlu2kw5AT0aoNvblOCl95NAwD3IOFMYOe/5hK1UzC/soa03tkIxbn5iNTwh2eLQ1dFuMAY1NE6rVfv3Q=="],
 
     "@types/node": ["@types/node@22.13.5", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg=="],
 
     "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
 
-    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
-
     "bn.js": ["bn.js@5.2.1", "", {}, "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="],
 
-    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
-
-    "buffer-pipe": ["buffer-pipe@0.0.5", "", { "dependencies": { "safe-buffer": "^5.2.0" } }, "sha512-a6kQxHM27rLrDpVFCKk9iirHKQU2fukg/j3XqIIOoc1rT/W5kp+KsIQmff6dJ7I3ErxmAasetarkeSG1iqGpkA=="],
+    "buffer-pipe": ["buffer-pipe@0.0.3", "", { "dependencies": { "safe-buffer": "^5.1.2" } }, "sha512-GlxfuD/NrKvCNs0Ut+7b1IHjylfdegMBxQIlZHj7bObKVQBxB5S84gtm2yu1mQ8/sSggceWBDPY0cPXgvX2MuA=="],
 
     "bun-types": ["bun-types@1.2.3", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-P7AeyTseLKAvgaZqQrvp3RqFM3yN9PlcLuSTe7SoJOfZkER73mLdT2vEQi8U64S1YvM/ldcNiQjn0Sn7H9lGgg=="],
-
-    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "leb128": ["leb128@0.0.5", "", { "dependencies": { "bn.js": "^5.0.0", "buffer-pipe": "0.0.3" } }, "sha512-elbNtfmu3GndZbesVF6+iQAfVjOXW9bM/aax9WwMlABZW+oK9sbAZEXoewaPHmL34sxa8kVwWsru8cNE/yn2gg=="],
 
@@ -62,12 +57,6 @@
 
     "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
-    "undici": ["undici@5.28.5", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA=="],
-
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
-
-    "warp-isomorphic": ["warp-isomorphic@1.0.7", "", { "dependencies": { "buffer": "^6.0.3", "undici": "^5.19.1" } }, "sha512-fXHbUXwdYqPm9fRPz8mjv5ndPco09aMQuTe4kXfymzOq8V6F3DLsg9cIafxvjms9/mc6eijzkLBJ63yjEENEjA=="],
-
-    "leb128/buffer-pipe": ["buffer-pipe@0.0.3", "", { "dependencies": { "safe-buffer": "^5.1.2" } }, "sha512-GlxfuD/NrKvCNs0Ut+7b1IHjylfdegMBxQIlZHj7bObKVQBxB5S84gtm2yu1mQ8/sSggceWBDPY0cPXgvX2MuA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,13 +8,12 @@
 		"fmt": "bunx biome check --write ."
 	},
 	"dependencies": {
-		"buffer-pipe": "^0.0.5",
-		"leb128": "^0.0.5",
-		"warp-isomorphic": "^1.0.7"
+		"leb128": "^0.0.5"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
-		"@types/bun": "latest"
+		"@types/bun": "latest",
+		"@types/leb128": "^0.0.0"
 	},
 	"peerDependencies": {
 		"typescript": "^5.7.3"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"type": "module",
 	"module": "src/index.js",
 	"main": "src/index.js",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"scripts": {
 		"fmt": "bunx biome check --write ."
 	},

--- a/src/buffer-pipe.js
+++ b/src/buffer-pipe.js
@@ -1,0 +1,62 @@
+export class Stream {
+	/**
+	 * Creates a new instance of a pipe
+	 * @param {Buffer} buf - an optional buffer to start with
+	 */
+	constructor(buf = Buffer.from([])) {
+		this.buffer = buf;
+		this._bytesRead = 0;
+		this._bytesWrote = 0;
+	}
+
+	/**
+	 * read `num` number of bytes from the pipe
+	 * @param {Number} num
+	 * @return {Buffer}
+	 */
+	read(num) {
+		this._bytesRead += num;
+		const data = this.buffer.slice(0, num);
+		this.buffer = this.buffer.slice(num);
+		return data;
+	}
+
+	/**
+	 * Wites a buffer to the pipe
+	 * @param {Buffer} buf
+	 */
+	write(buf) {
+		if (!(buf instanceof Buffer)) {
+			buf = Buffer.from(buf);
+		}
+		this._bytesWrote += buf.length;
+		this.buffer = Buffer.concat(
+			[this.buffer, buf],
+			this.buffer.length + buf.length,
+		);
+	}
+
+	/**
+	 * Whether or not there is more data to read from the buffer
+	 * returns {Boolean}
+	 */
+	get end() {
+		return !this.buffer.length;
+	}
+
+	/**
+	 * returns the number of bytes read from the stream
+	 * @return {Integer}
+	 */
+	get bytesRead() {
+		return this._bytesRead;
+	}
+
+	/**
+	 * returns the number of bytes wrote to the stream
+	 * @return {Integer}
+	 */
+	get bytesWrote() {
+		return this._bytesWrote;
+	}
+}

--- a/src/memory.test.ts
+++ b/src/memory.test.ts
@@ -23,4 +23,26 @@ describe("memory", () => {
 		// Ensure that the WASM module is valid
 		expect(() => new WebAssembly.Module(result)).not.toThrow();
 	});
+
+	it("should be fast", async () => {
+		const wasmBytes = await Bun.file(
+			resolve(import.meta.dir, "../import_memory_from_env.wasm"),
+		).bytes();
+
+		let result: Buffer;
+		let totalTime = 0;
+
+		for (let i = 0; i < 1000; i++) {
+			const start = performance.now();
+			result = meterWasm(Buffer.from(wasmBytes), costTable);
+			const end = performance.now();
+			totalTime += end - start;
+		}
+
+		const avgTime = totalTime / 1000;
+
+		// Ensure that the WASM module is valid
+		expect(() => new WebAssembly.Module(result)).not.toThrow();
+		expect(avgTime).toBeLessThan(0.3);
+	});
 });

--- a/src/meter-json.js
+++ b/src/meter-json.js
@@ -1,103 +1,103 @@
-const text2json = require("./text2json.js");
-const SECTION_IDS = require("./json2wasm.js").SECTION_IDS;
+import { SECTION_IDS } from "./json2wasm.js";
+import { text2json } from "./text2json.js";
 
 // gets the cost of an operation for entry in a section from the cost table
 function getCost(json, costTable = {}, defaultCost = 0) {
-  let cost = 0;
-  // finds the default cost
-  const fallbackCost =
-    costTable.DEFAULT !== undefined ? costTable.DEFAULT : defaultCost;
+	let cost = 0;
+	// finds the default cost
+	const fallbackCost =
+		costTable.DEFAULT !== undefined ? costTable.DEFAULT : defaultCost;
 
-  if (Array.isArray(json)) {
-    for (const el of json) {
-      cost += getCost(el, costTable);
-    }
-  } else if (typeof json === "object") {
-    for (const propName in json) {
-      const propCost = costTable[propName];
-      if (propCost) {
-        cost += getCost(json[propName], propCost, fallbackCost);
-      }
-    }
-  } else if (costTable[json] === undefined) {
-    cost = fallbackCost;
-  } else {
-    cost = costTable[json];
-  }
-  return cost;
+	if (Array.isArray(json)) {
+		for (const el of json) {
+			cost += getCost(el, costTable);
+		}
+	} else if (typeof json === "object") {
+		for (const propName in json) {
+			const propCost = costTable[propName];
+			if (propCost) {
+				cost += getCost(json[propName], propCost, fallbackCost);
+			}
+		}
+	} else if (costTable[json] === undefined) {
+		cost = fallbackCost;
+	} else {
+		cost = costTable[json];
+	}
+	return cost;
 }
 
 // meters a single code entry
 function meterCodeEntry(entry, costTable, cost, meterIndex, exhaustedIndex) {
-  // Generate the metering opcodes similar to how Wasmer does it.
-  function meteringStatement(accumulatedCost) {
-    return text2json(`get_global ${meterIndex}`)
-      .concat(text2json(`i64.const ${accumulatedCost}`))
-      .concat(text2json("i64.lt_u"))
-      .concat([{ name: "if", immediates: "block_type" }])
-      .concat(text2json("i32.const 1"))
-      .concat(text2json(`set_global ${exhaustedIndex}`))
-      .concat(text2json("unreachable"))
-      .concat(text2json("end"))
-      .concat(text2json(`get_global ${meterIndex}`))
-      .concat(text2json(`i64.const ${accumulatedCost}`))
-      .concat(text2json("i64.sub"))
-      .concat(text2json(`set_global ${meterIndex}`));
-  }
+	// Generate the metering opcodes similar to how Wasmer does it.
+	function meteringStatement(accumulatedCost) {
+		return text2json(`get_global ${meterIndex}`)
+			.concat(text2json(`i64.const ${accumulatedCost}`))
+			.concat(text2json("i64.lt_u"))
+			.concat([{ name: "if", immediates: "block_type" }])
+			.concat(text2json("i32.const 1"))
+			.concat(text2json(`set_global ${exhaustedIndex}`))
+			.concat(text2json("unreachable"))
+			.concat(text2json("end"))
+			.concat(text2json(`get_global ${meterIndex}`))
+			.concat(text2json(`i64.const ${accumulatedCost}`))
+			.concat(text2json("i64.sub"))
+			.concat(text2json(`set_global ${meterIndex}`));
+	}
 
-  // operations that can possible cause a branch
-  const branchingOps = new Set([
-    "loop",
-    "end",
-    "if",
-    "else",
-    "br",
-    "br_table",
-    "br_if",
-    "call",
-    "call_indirect",
-    "return",
-  ]);
+	// operations that can possible cause a branch
+	const branchingOps = new Set([
+		"loop",
+		"end",
+		"if",
+		"else",
+		"br",
+		"br_table",
+		"br_if",
+		"call",
+		"call_indirect",
+		"return",
+	]);
 
-  let code = entry.code.slice();
-  let meteredCode = [];
+	let code = entry.code.slice();
+	let meteredCode = [];
 
-  cost += getCost(entry.locals, costTable.local);
+	cost += getCost(entry.locals, costTable.local);
 
-  while (code.length) {
-    let i = 0;
+	while (code.length) {
+		let i = 0;
 
-    // meters a segment of wasm code
-    while (true) {
-      const op = code[i++];
+		// meters a segment of wasm code
+		while (true) {
+			const op = code[i++];
 
-      cost += getCost(op.name, costTable.code);
-      if (branchingOps.has(op.name)) {
-        break;
-      }
-    }
+			cost += getCost(op.name, costTable.code);
+			if (branchingOps.has(op.name)) {
+				break;
+			}
+		}
 
-    // get the segment of code to be metered
-    let segment = code.slice(0, i);
+		// get the segment of code to be metered
+		let segment = code.slice(0, i);
 
-    // add the metering statement when there's a cost to meter
-    if (cost !== 0) {
-      const mStatement = meteringStatement(cost);
-      // Mimic wasmer's behavior by inserting the metering statement before the last operation
-      const lastOp = segment.pop();
-      segment = segment.concat(mStatement);
-      segment.push(lastOp);
-    }
+		// add the metering statement when there's a cost to meter
+		if (cost !== 0) {
+			const mStatement = meteringStatement(cost);
+			// Mimic wasmer's behavior by inserting the metering statement before the last operation
+			const lastOp = segment.pop();
+			segment = segment.concat(mStatement);
+			segment.push(lastOp);
+		}
 
-    meteredCode = meteredCode.concat(segment);
+		meteredCode = meteredCode.concat(segment);
 
-    // start a new segment
-    code = code.slice(i);
-    cost = 0;
-  }
+		// start a new segment
+		code = code.slice(i);
+		cost = 0;
+	}
 
-  entry.code = meteredCode;
-  return entry;
+	entry.code = meteredCode;
+	return entry;
 }
 
 /**
@@ -106,108 +106,108 @@ function meterCodeEntry(entry, costTable, cost, meterIndex, exhaustedIndex) {
  * @param {Object} costTable the cost table to meter with.
  * @return {Object} the metered json
  */
-exports.meterJSON = (json, costTable) => {
-  function findSection(module, sectionName) {
-    return module.find((section) => section.name === sectionName);
-  }
+export function meterJSON(json, costTable) {
+	function findSection(module, sectionName) {
+		return module.find((section) => section.name === sectionName);
+	}
 
-  function createSection(module, name) {
-    const newSectionId = SECTION_IDS[name];
-    for (const index in module) {
-      const section = module[index];
-      const sectionId = SECTION_IDS[section.name];
-      if (sectionId) {
-        if (newSectionId < sectionId) {
-          // inject a new section
-          module.splice(index, 0, {
-            name,
-            entries: [],
-          });
-          return;
-        }
-      }
-    }
-  }
+	function createSection(module, name) {
+		const newSectionId = SECTION_IDS[name];
+		for (const index in module) {
+			const section = module[index];
+			const sectionId = SECTION_IDS[section.name];
+			if (sectionId) {
+				if (newSectionId < sectionId) {
+					// inject a new section
+					module.splice(index, 0, {
+						name,
+						entries: [],
+					});
+					return;
+				}
+			}
+		}
+	}
 
-  // add nessicarry sections iff they don't exist
-  if (!findSection(json, "export")) createSection(json, "export");
-  if (!findSection(json, "global")) createSection(json, "global");
+	// add nessicarry sections iff they don't exist
+	if (!findSection(json, "export")) createSection(json, "export");
+	if (!findSection(json, "global")) createSection(json, "global");
 
-  const globalMeteringPoints = {
-    type: {
-      contentType: "i64",
-      mutability: 1,
-    },
-    init: {
-      return_type: "i64",
-      name: "const",
-      // We set the initial gas limit to 0 and expect the caller to set the gas limit
-      // through the export.
-      immediates: "0",
-    },
-  };
-  const globalOutOfGas = {
-    type: {
-      contentType: "i32",
-      mutability: 1,
-    },
-    init: {
-      return_type: "i32",
-      name: "const",
-      immediates: "0",
-    },
-  };
+	const globalMeteringPoints = {
+		type: {
+			contentType: "i64",
+			mutability: 1,
+		},
+		init: {
+			return_type: "i64",
+			name: "const",
+			// We set the initial gas limit to 0 and expect the caller to set the gas limit
+			// through the export.
+			immediates: "0",
+		},
+	};
+	const globalOutOfGas = {
+		type: {
+			contentType: "i32",
+			mutability: 1,
+		},
+		init: {
+			return_type: "i32",
+			name: "const",
+			immediates: "0",
+		},
+	};
 
-  const exportMeteringPoints = {
-    field_str: "metering_remaining_points",
-    kind: "global",
-    index: Number.NaN,
-  };
-  const exportOutOfGas = {
-    field_str: "metering_points_exhausted",
-    kind: "global",
-    index: Number.NaN,
-  };
+	const exportMeteringPoints = {
+		field_str: "metering_remaining_points",
+		kind: "global",
+		index: Number.NaN,
+	};
+	const exportOutOfGas = {
+		field_str: "metering_points_exhausted",
+		kind: "global",
+		index: Number.NaN,
+	};
 
-  json = json.slice(0);
+	json = json.slice(0);
 
-  for (let section of json) {
-    section = Object.assign(section);
-    switch (section.name) {
-      case "type":
-        break;
-      case "function":
-        break;
-      case "import":
-        break;
-      case "export":
-        section.entries.push(exportMeteringPoints);
-        section.entries.push(exportOutOfGas);
-        break;
-      case "element":
-        break;
-      case "start":
-        break;
-      case "global":
-        exportMeteringPoints.index =
-          section.entries.push(globalMeteringPoints) - 1;
-        exportOutOfGas.index = section.entries.push(globalOutOfGas) - 1;
-        break;
-      case "code":
-        for (const i in section.entries) {
-          const entry = section.entries[i];
+	for (let section of json) {
+		section = Object.assign(section);
+		switch (section.name) {
+			case "type":
+				break;
+			case "function":
+				break;
+			case "import":
+				break;
+			case "export":
+				section.entries.push(exportMeteringPoints);
+				section.entries.push(exportOutOfGas);
+				break;
+			case "element":
+				break;
+			case "start":
+				break;
+			case "global":
+				exportMeteringPoints.index =
+					section.entries.push(globalMeteringPoints) - 1;
+				exportOutOfGas.index = section.entries.push(globalOutOfGas) - 1;
+				break;
+			case "code":
+				for (const i in section.entries) {
+					const entry = section.entries[i];
 
-          meterCodeEntry(
-            entry,
-            costTable.code,
-            0,
-            exportMeteringPoints.index,
-            exportOutOfGas.index
-          );
-        }
-        break;
-    }
-  }
+					meterCodeEntry(
+						entry,
+						costTable.code,
+						0,
+						exportMeteringPoints.index,
+						exportOutOfGas.index,
+					);
+				}
+				break;
+		}
+	}
 
-  return json;
-};
+	return json;
+}

--- a/src/preallocated-buffer.ts
+++ b/src/preallocated-buffer.ts
@@ -1,0 +1,57 @@
+/**
+ * A buffer class that pre-allocates memory and grows as needed.
+ * Similar to Stream but with a simpler implementation focused on Buffer operations.
+ * Pre-allocates a fixed size buffer and automatically grows it when more space is needed.
+ * More efficient than creating new buffers for each write operation.
+ */
+export class PreallocatedBuffer {
+	private buf: Buffer;
+	private written = 0;
+
+	constructor(size = 10_000) {
+		this.buf = Buffer.alloc(size);
+	}
+
+	/**
+	 * Writes a buffer to the pre-allocated buffer. Will grow the buffer as needed.
+	 * @param {Buffer} newBuffer - The buffer to write.
+	 */
+	write(newBuffer: Buffer | number[]) {
+		if (typeof newBuffer === "string") {
+			// biome-ignore lint/style/noParameterAssign: Compatiblity fix :(
+			newBuffer = Buffer.from(newBuffer);
+		}
+		if (this.buf.length - this.written <= newBuffer.length) {
+			const oldBuffer = this.buf;
+			// Aggressively double the buffer size
+			this.buf = Buffer.alloc((this.buf.length + newBuffer.length) * 2);
+			this.buf.set(oldBuffer);
+		}
+
+		this.buf.set(newBuffer, this.written);
+		this.written += newBuffer.length;
+	}
+
+	/**
+	 * Not implemented, but present for compatibility with Stream.
+	 */
+	read(size: number): Buffer {
+		throw new Error("Not implemented");
+	}
+
+	/**
+	 * Returns the number of bytes written to the buffer.
+	 * @returns {number} The number of bytes written.
+	 */
+	get bytesWrote(): number {
+		return this.written;
+	}
+
+	/**
+	 * Returns the current buffer as a subarray of the pre-allocated buffer.
+	 * @returns {Buffer} The current buffer.
+	 */
+	get buffer(): Buffer {
+		return this.buf.subarray(0, this.written);
+	}
+}

--- a/src/text2json.js
+++ b/src/text2json.js
@@ -1,6 +1,6 @@
-const immediates = require("./immediates.js").OP_IMMEDIATES;
+import { OP_IMMEDIATES as immediates } from "./immediates.js";
 
-module.exports = (text) => {
+export function text2json(text) {
 	const json = [];
 	const textArray = text.split(/\s|\n/);
 	while (textArray.length) {
@@ -27,7 +27,7 @@ module.exports = (text) => {
 		json.push(jsonOp);
 	}
 	return json;
-};
+}
 
 function immediataryParser(type, txt) {
 	const json = {};

--- a/src/wasm2json.js
+++ b/src/wasm2json.js
@@ -1,10 +1,10 @@
-import Stream from "buffer-pipe";
 /**
  * This code is an adaptation over https://github.com/warp-contracts/warp-wasm-json-toolkit/blob/main/wasm2json.js.
  *
  * License: MPL-2.0
  */
 import leb from "leb128";
+import { Stream } from "./buffer-pipe.js";
 import { OP_IMMEDIATES } from "./immediates.js";
 
 const wasm2json = (buf, filter) => {


### PR DESCRIPTION
## Motivation

Speeds up the compilation and injecting the metering code significantly.

## Explanation of Changes

Went for the easy fixes first: use a buffer that aggressively preallocates and grows as needed, and remove text parsing code.

I think we could do a lot more, but these simple changes are already a huge improvement.

## Testing

Added a unit test to keep the speed in check, as well as running benchmark tests on the `test-vm.wasm`

```js
import fs from "node:fs";
import { resolve } from "node:path";
import { costTable } from "./src/cost-table-example.js";
import { meterWasm } from "./src/index.js";

const input = fs.readFileSync(
	resolve("../seda-sdk/libs/wasm-integration-tests/test-vm.wasm"),
);

const iterations = 50;
let totalTime = 0;

for (let i = 0; i < iterations; i++) {
	const start = process.hrtime.bigint();
	const result = meterWasm(input, costTable);
	new WebAssembly.Module(result);
	const end = process.hrtime.bigint();
	totalTime += Number(end - start);
}

const avgTimeMs = totalTime / iterations / 1e6;
console.log(
	`Average time per run: ${avgTimeMs.toFixed(3)} ms over ${iterations} iterations`,
);
```

Before: `Average time per run: 503.991 ms over 50 iterations`
After: `Average time per run: 127.012 ms over 50 iterations`

`console.time` for the big sections:
```
[66.84ms] wasm2json
[0.07ms] injectMemoryLimit
[53.31ms] meterJSON
[77.45ms] json2wasm
```

They speed up on subsequent runs but not sure if that's relevant in our case as well.

## Related PRs and Issues

N.A.
